### PR TITLE
Raumselektion überarbeitet. Fixes #279

### DIFF
--- a/integrationTests.xml
+++ b/integrationTests.xml
@@ -6,6 +6,7 @@
 			<class name="org.woym.persistence.DataAccessObjectsIT" />
 			<class name="org.woym.persistence.DataAccessObjectsIT2" />
 			<class name="org.woym.logic.command.integration.CommandsDataAccessIT" />
+			<class name="org.woym.controller.planning.PlanningControllerIT" />
 		</classes>
 	</test>
 </suite>

--- a/src/main/java/org/woym/common/objects/Room.java
+++ b/src/main/java/org/woym/common/objects/Room.java
@@ -26,6 +26,9 @@ public class Room extends org.woym.common.objects.Entity implements
 	 * 
 	 */
 	private static final long serialVersionUID = 1530008000910481387L;
+
+	public static final String DEFAULT_PURPOSE = "Standardraum";
+
 	/**
 	 * Die automatisch generierte ID ist der Primärschlüssel für die Datenbank.
 	 */
@@ -42,7 +45,7 @@ public class Room extends org.woym.common.objects.Entity implements
 	/**
 	 * Funktion des Raumes.
 	 */
-	private String purpose = "Standardraum";
+	private String purpose = DEFAULT_PURPOSE;
 
 	/**
 	 * Zusätzliche Informationen zu dem Raum.

--- a/src/main/java/org/woym/controller/planning/LessonController.java
+++ b/src/main/java/org/woym/controller/planning/LessonController.java
@@ -160,7 +160,8 @@ public class LessonController implements Serializable {
 
 			if (status instanceof SuccessStatus) {
 				init();
-				RequestContext.getCurrentInstance().execute("PF('wAddActivityDialog').hide()");
+				RequestContext.getCurrentInstance().execute(
+						"PF('wAddActivityDialog').hide()");
 			}
 		}
 
@@ -251,19 +252,25 @@ public class LessonController implements Serializable {
 		TimePeriod timePeriod = lesson.getTime();
 		timePeriod.setEndTime(endTime);
 		lesson.setTime(timePeriod);
-		
-		if(!lessonType.getRooms().isEmpty()) {
-			location = lessonType.getRooms().get(0).getLocation();
-			setLessonRoom(lessonType.getRooms().get(0));
-		} else {
-			for(Schoolclass schoolclass : lesson.getSchoolclasses()) {
-				if(schoolclass.getRoom() != null) {
-					location = schoolclass.getRoom().getLocation();
-					setLessonRoom(schoolclass.getRoom());
-					break;
+
+		try {
+			if (!lessonType.getRooms().isEmpty()
+					&& dataAccess.containsSpecialRooms(lessonType)) {
+				location = lessonType.getRooms().get(0).getLocation();
+				setLessonRoom(lessonType.getRooms().get(0));
+			} else {
+				for (Schoolclass schoolclass : lesson.getSchoolclasses()) {
+					if (schoolclass.getRoom() != null) {
+						location = schoolclass.getRoom().getLocation();
+						setLessonRoom(schoolclass.getRoom());
+						break;
+					}
 				}
 			}
+		} catch (DatasetException e) {
+			LOGGER.error(e.getMessage());
 		}
+
 	}
 
 	public Schoolclass getLessonSchoolclass() {
@@ -291,6 +298,19 @@ public class LessonController implements Serializable {
 			List<Schoolclass> schoolclasses = new ArrayList<>();
 			schoolclasses.add(schoolclass);
 			lesson.setSchoolclasses(schoolclasses);
+			try {
+
+				if (lesson.getRooms().isEmpty()
+						|| !dataAccess.containsSpecialRooms(lesson
+								.getLessonType())) {
+					if (schoolclass.getRoom() != null) {
+						location = schoolclass.getRoom().getLocation();
+						setLessonRoom(schoolclass.getRoom());
+					}
+				}
+			} catch (DatasetException e) {
+				LOGGER.error(e.getMessage());
+			}
 		}
 	}
 

--- a/src/main/java/org/woym/controller/planning/LessonController.java
+++ b/src/main/java/org/woym/controller/planning/LessonController.java
@@ -370,4 +370,13 @@ public class LessonController implements Serializable {
 		this.location = location;
 	}
 
+	public void setFirstSchoolclass() {
+		if (academicYear != null) {
+			List<Schoolclass> schoolclasses = getSchoolclassesForAcademicYear();
+			if (!schoolclasses.isEmpty()) {
+				setLessonSchoolclass(schoolclasses.get(0));
+			}
+		}
+	}
+
 }

--- a/src/main/java/org/woym/controller/planning/PlanningController.java
+++ b/src/main/java/org/woym/controller/planning/PlanningController.java
@@ -501,7 +501,7 @@ public class PlanningController implements Serializable {
 			if (status instanceof SuccessStatus) {
 
 				MacroCommand macro = commandCreator
-						.createEmployeeUpdateSubstractWorkingHours(activity);
+						.createEmployeeUpdateSubtractWorkingHours(activity);
 				activity.setTime(time);
 				for (EmployeeTimePeriods timePeriods : activity
 						.getEmployeeTimePeriods()) {

--- a/src/main/java/org/woym/logic/command/CommandCreator.java
+++ b/src/main/java/org/woym/logic/command/CommandCreator.java
@@ -132,7 +132,7 @@ public class CommandCreator {
 	 * @return {@linkplain MacroCommand} mit den UpdateCommands für die
 	 *         Mitarbeiter
 	 */
-	public MacroCommand createEmployeeUpdateSubstractWorkingHours(
+	public MacroCommand createEmployeeUpdateSubtractWorkingHours(
 			final Activity activity) {
 
 		if (activity == null) {
@@ -204,7 +204,7 @@ public class CommandCreator {
 		if (entity instanceof Activity) {
 			// Beim Löschen einer Aktivität müssen die verteilten Stunden der
 			// beteiligten Lehrer aktualisiert werden
-			macro.addAll(createEmployeeUpdateSubstractWorkingHours((Activity) entity));
+			macro.addAll(createEmployeeUpdateSubtractWorkingHours((Activity) entity));
 
 			macro.add(new DeleteCommand<Entity>(entity));
 		} else {
@@ -316,7 +316,7 @@ public class CommandCreator {
 			if (size == 0) {
 				a.setMemento(memento);
 				a.update();
-				macro.addAll(createEmployeeUpdateSubstractWorkingHours(a).getCommands());
+				macro.addAll(createEmployeeUpdateSubtractWorkingHours(a).getCommands());
 				macro.add(new DeleteCommand<Entity>(a));
 			} else if (size > 0) {
 				macro.add(new UpdateCommand<Entity>(a, memento));

--- a/src/main/java/org/woym/persistence/DataAccess.java
+++ b/src/main/java/org/woym/persistence/DataAccess.java
@@ -9,6 +9,7 @@ import java.util.Observer;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -682,6 +683,32 @@ public class DataAccess implements IDataAccess, Observer {
 			throw new DatasetException(
 					"Error while getting ActivityType with name " + name + " "
 							+ e.getMessage());
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean containsSpecialRooms(ActivityType type)
+			throws DatasetException {
+		if (type == null) {
+			throw new IllegalArgumentException("Parameter was null.");
+		}
+		try {
+			final TypedQuery<Integer> query = em
+					.createQuery(
+							"SELECT CASE WHEN (COUNT(r) > 0) THEN 1 ELSE 0 END"
+									+ " FROM ActivityType a INNER JOIN a.rooms r WHERE a = ?1 AND r.purpose <> ?2",
+							Integer.class);
+			query.setParameter(1, type);
+			query.setParameter(2, Room.DEFAULT_PURPOSE);
+			return query.getSingleResult() == 1 ? true : false;
+		} catch (Exception e) {
+			LOGGER.error("Exception while checking activity type " + type
+					+ " for special rooms.", e);
+			throw new DatasetException("Error while checking activity type "
+					+ type + " for special rooms: " + e.getMessage());
 		}
 	}
 

--- a/src/main/java/org/woym/persistence/spec/IActivityTypeDAO.java
+++ b/src/main/java/org/woym/persistence/spec/IActivityTypeDAO.java
@@ -91,4 +91,20 @@ public interface IActivityTypeDAO {
 	 */
 	public ActivityType getOneActivityType(String name) throws DatasetException;
 
+	/**
+	 * Gibt {@code true} zurück, wenn der übergebene Aktivitätstyp einen Raum
+	 * besitzt, der nicht Standardraum ist. Ansonsten wird {@code false}
+	 * zurückgegeben. Tritt dabei ein Fehler auf, wird eine
+	 * {@linkplain DatasetException} geworfen.
+	 * 
+	 * @param type
+	 *            - Aktivitätstyp, für welchen geprüft werden soll, ob er
+	 *            spezielle Räume enthält
+	 * @return {@code true}, wenn der Aktivitätstyp spezielle Räume enthält,
+	 *         ansonsten {@code false}
+	 * @throws DatasetException
+	 */
+	public boolean containsSpecialRooms(ActivityType type)
+			throws DatasetException;
+
 }

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -428,7 +428,8 @@
 								converter="AcademicYearNameConverter" required="true"
 								requiredMessage="Es muss ein Jahrgang ausgewählt werden.">
 								<p:ajax event="change" process="@this"
-									update="lessonSchoolclassPanel" />
+									listener="#{lessonController.setFirstSchoolclass}"
+									update="lessonSchoolclassPanel,lessonRoomPanel" />
 								<f:selectItem value="#{null}" itemLabel="Jahrgang auswählen" />
 								<f:selectItems
 									value="#{academicYearAndClassController.academicYears}"

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -443,7 +443,7 @@
 								rendered="#{lessonController.academicYear != null}"
 								required="true"
 								requiredMessage="Es muss eine Schulklasse ausgewählt werden.">
-								<p:ajax event="change" process="@this" />
+								<p:ajax event="change" process="@this" update="lessonRoomPanel" />
 								<f:selectItem value="#{null}" itemLabel="Klasse auswählen" />
 								<f:selectItems
 									value="#{lessonController.schoolclassesForAcademicYear}"

--- a/src/test/java/org/woym/controller/planning/ContextMocker.java
+++ b/src/test/java/org/woym/controller/planning/ContextMocker.java
@@ -1,0 +1,53 @@
+package org.woym.controller.planning;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public abstract class ContextMocker extends FacesContext {
+
+	private FacesMessage msg;
+
+	private ContextMocker() {
+	}
+
+	private static final Release RELEASE = new Release();
+
+	private static class Release implements Answer<Void> {
+		@Override
+		public Void answer(InvocationOnMock invocation) throws Throwable {
+			setCurrentInstance(null);
+			return null;
+		}
+	}
+
+	public static FacesContext mockFacesContext() {
+		FacesContext context = Mockito.mock(ContextMocker.class);
+		setCurrentInstance(context);
+		Mockito.doAnswer(RELEASE).when(context).release();
+		Mockito.doCallRealMethod()
+				.when(context)
+				.addMessage(Mockito.anyString(),
+						Mockito.any(FacesMessage.class));
+		Mockito.doCallRealMethod().when(context).getMessageList();
+		return context;
+	}
+
+	@Override
+	public void addMessage(String clientId, FacesMessage message) {
+		msg = message;
+	}
+
+	@Override
+	public List<FacesMessage> getMessageList() {
+		List<FacesMessage> list = new ArrayList<FacesMessage>();
+		list.add(msg);
+		return list;
+	}
+}

--- a/src/test/java/org/woym/controller/planning/PlanningControllerIT.java
+++ b/src/test/java/org/woym/controller/planning/PlanningControllerIT.java
@@ -1,0 +1,155 @@
+package org.woym.controller.planning;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.util.List;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.primefaces.event.ScheduleEntryMoveEvent;
+import org.primefaces.model.ScheduleEvent;
+import org.testng.annotations.Test;
+import org.woym.common.messages.GenericErrorMessage;
+import org.woym.common.objects.Lesson;
+import org.woym.common.objects.LessonType;
+import org.woym.common.objects.Weekday;
+import org.woym.persistence.DataAccess;
+
+@Test(groups = { "PlanningControllerIT", "integration" }, dependsOnGroups = {
+		"DataAccessObjectsIT", "DataAccessObjectsIT2", "CommandsDataAccessIT" })
+public class PlanningControllerIT extends PowerMockTestCase {
+
+	private PlanningController planningController;
+
+	private DataAccess dataAccess = DataAccess.getInstance();
+
+	private FacesContext facesContext = ContextMocker.mockFacesContext();
+
+	@Mock
+	private ScheduleEntryMoveEvent event;
+
+	@Mock
+	private ScheduleEvent scheduleEvent;
+
+	@SuppressWarnings("deprecation")
+	@Test(priority = 1)
+	public void onEventMoveSuccess() throws Exception {
+		init();
+
+		Lesson lesson = dataAccess.getAllLessons(
+				(LessonType) dataAccess.getOneActivityType("Mathe")).get(0);
+
+		Mockito.when(event.getScheduleEvent()).thenReturn(scheduleEvent);
+		Mockito.when(scheduleEvent.getData()).thenReturn(lesson);
+		Mockito.when(event.getDayDelta()).thenReturn(2);
+		Mockito.when(event.getMinuteDelta()).thenReturn(0);
+
+		planningController.onEventMove(event);
+
+		lesson = dataAccess.getAllLessons(
+				(LessonType) dataAccess.getOneActivityType("Mathe")).get(0);
+		assertEquals(Weekday.WEDNESDAY, lesson.getTime().getDay());
+		assertEquals(10, lesson.getTime().getStartTime().getHours());
+		assertEquals(45, lesson.getTime().getEndTime().getMinutes());
+
+	}
+
+	@Test(dependsOnMethods = "onEventMoveSuccess")
+	public void onEventMoveInvalidWeekday() throws Exception {
+		Lesson lesson = dataAccess.getAllLessons(
+				(LessonType) dataAccess.getOneActivityType("Mathe")).get(0);
+
+		Mockito.when(event.getScheduleEvent()).thenReturn(scheduleEvent);
+		Mockito.when(scheduleEvent.getData()).thenReturn(lesson);
+		Mockito.when(event.getDayDelta()).thenReturn(3);
+		Mockito.when(event.getMinuteDelta()).thenReturn(0);
+
+		planningController.onEventMove(event);
+		List<FacesMessage> messages = facesContext.getMessageList();
+		assertEquals(1, messages.size());
+		assertEquals(GenericErrorMessage.INVALID_WEEKDAY.getSummary(), messages
+				.get(0).getSummary());
+	}
+
+	@Test(dependsOnMethods = "onEventMoveSuccess")
+	public void onEventMoveStartTimeOutOfRange() throws Exception {
+		Lesson lesson = dataAccess.getAllLessons(
+				(LessonType) dataAccess.getOneActivityType("Mathe")).get(0);
+
+		Mockito.when(event.getScheduleEvent()).thenReturn(scheduleEvent);
+		Mockito.when(scheduleEvent.getData()).thenReturn(lesson);
+		Mockito.when(event.getDayDelta()).thenReturn(0);
+		Mockito.when(event.getMinuteDelta()).thenReturn(-180);
+
+		planningController.onEventMove(event);
+		List<FacesMessage> messages = facesContext.getMessageList();
+		assertEquals(1, messages.size());
+		assertEquals(GenericErrorMessage.TIME_OUTSIDE_LIMIT.getSummary(),
+				messages.get(0).getSummary());
+	}
+
+	@Test(dependsOnMethods = "onEventMoveSuccess")
+	public void onEventMoveEndTimeOutOfRange() throws Exception {
+		Lesson lesson = dataAccess.getAllLessons(
+				(LessonType) dataAccess.getOneActivityType("Mathe")).get(0);
+
+		Mockito.when(event.getScheduleEvent()).thenReturn(scheduleEvent);
+		Mockito.when(scheduleEvent.getData()).thenReturn(lesson);
+		Mockito.when(event.getDayDelta()).thenReturn(0);
+		Mockito.when(event.getMinuteDelta()).thenReturn(320);
+
+		planningController.onEventMove(event);
+		List<FacesMessage> messages = facesContext.getMessageList();
+		assertEquals(1, messages.size());
+		assertEquals(GenericErrorMessage.TIME_OUTSIDE_LIMIT.getSummary(),
+				messages.get(0).getSummary());
+	}
+
+	@Test(dependsOnMethods = "onEventMoveSuccess")
+	public void onEventMoveTimePeriodValidationFail() throws Exception {
+		Lesson lesson = dataAccess.getAllLessons(
+				(LessonType) dataAccess.getOneActivityType("Mathe")).get(0);
+
+		Mockito.when(event.getScheduleEvent()).thenReturn(scheduleEvent);
+		Mockito.when(scheduleEvent.getData()).thenReturn(lesson);
+		Mockito.when(event.getDayDelta()).thenReturn(-2);
+		Mockito.when(event.getMinuteDelta()).thenReturn(10);
+
+		planningController.onEventMove(event);
+		List<FacesMessage> messages = facesContext.getMessageList();
+		assertEquals(1, messages.size());
+		assertEquals("Validierung fehlgeschlagen.", messages.get(0)
+				.getSummary());
+	}
+
+	@Test(dependsOnMethods = "onEventMoveSuccess")
+	public void onEventMoveNotExistingWeekday() throws Exception {
+		Lesson lesson = dataAccess.getAllLessons(
+				(LessonType) dataAccess.getOneActivityType("Mathe")).get(0);
+
+		Mockito.when(event.getScheduleEvent()).thenReturn(scheduleEvent);
+		Mockito.when(scheduleEvent.getData()).thenReturn(lesson);
+		Mockito.when(event.getDayDelta()).thenReturn(-3);
+		Mockito.when(event.getMinuteDelta()).thenReturn(0);
+
+		planningController.onEventMove(event);
+		List<FacesMessage> messages = facesContext.getMessageList();
+		assertEquals(1, messages.size());
+		assertEquals(
+				GenericErrorMessage.INVALID_WEEKDAY_IN_DISPLAY.getSummary(),
+				messages.get(0).getSummary());
+	}
+
+	private void init() {
+		planningController = new PlanningController();
+		ExternalContext externalContext = Mockito.mock(ExternalContext.class);
+		Mockito.when(facesContext.getExternalContext()).thenReturn(
+				externalContext);
+		planningController.init();
+	}
+}

--- a/src/test/java/org/woym/logic/command/TestCommandCreator.java
+++ b/src/test/java/org/woym/logic/command/TestCommandCreator.java
@@ -556,7 +556,7 @@ public class TestCommandCreator extends PowerMockTestCase {
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
 	public void testCreateEmployeeUpdateSubstractWorkingHours() {
-		CommandCreator.getInstance().createEmployeeUpdateSubstractWorkingHours(
+		CommandCreator.getInstance().createEmployeeUpdateSubtractWorkingHours(
 				null);
 	}
 
@@ -588,7 +588,7 @@ public class TestCommandCreator extends PowerMockTestCase {
 		Mockito.when(teacher.getAllocatedHours()).thenReturn(BigDecimal.ONE);
 
 		MacroCommand macro = CommandCreator.getInstance()
-				.createEmployeeUpdateSubstractWorkingHours(activity);
+				.createEmployeeUpdateSubtractWorkingHours(activity);
 
 		AssertJUnit.assertEquals(1, macro.getCommands().size());
 		AssertJUnit
@@ -627,7 +627,7 @@ public class TestCommandCreator extends PowerMockTestCase {
 				BigDecimal.ONE);
 
 		MacroCommand macro = CommandCreator.getInstance()
-				.createEmployeeUpdateSubstractWorkingHours(activity);
+				.createEmployeeUpdateSubtractWorkingHours(activity);
 
 		AssertJUnit.assertEquals(1, macro.getCommands().size());
 		AssertJUnit

--- a/src/test/java/org/woym/logic/util/ActivityParserTest.java
+++ b/src/test/java/org/woym/logic/util/ActivityParserTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.primefaces.model.ScheduleModel;
@@ -33,6 +34,7 @@ import org.woym.common.objects.Weekday;
 import org.woym.persistence.DataAccess;
 
 @Test(groups = "unit")
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest(Config.class)
 public class ActivityParserTest extends PowerMockTestCase {
 


### PR DESCRIPTION
Automatische Raumselektion im Dialog zum Hinzufügen einer Unterrichtsstunde überarbeitet, so dass, wenn der Aktivitätstyp keinen speziellen Raum (sondern nur Standardräume) besitzt, der Klassenraum der Klasse als Raum für die Aktivität gesetzt wird. 
