### PR TITLE
Fixes #282

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<!-- General -->
 	<groupId>org.woym</groupId>
 	<artifactId>timetable</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 
 	<!-- Packaging -->
 	<packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<!-- General -->
 	<groupId>org.woym</groupId>
 	<artifactId>timetable</artifactId>
-	<version>0.2.0</version>
+	<version>1.0.0</version>
 
 	<!-- Packaging -->
 	<packaging>war</packaging>

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -19,8 +19,9 @@
 		<p:hotkey bind="ctrl+y" update="@form"
 			actionListener="#{GUIController.redo}" />
 
-
 		<p:growl id="commandGrowl" widgetVar="wCommandGrowl" showDetail="true" />
+		<p:growl id="activityGrowl" widgetVar="wActivityGrowl" showDetail="true" severity="info,warn" />
+		
 		<p:toolbar id="setupToolbar">
 			<f:facet name="left">
 				<p:commandButton value="Systemeinrichtung" icon="ui-icon-gear"
@@ -483,7 +484,7 @@
 								<p:commandButton id="LessonAddButton" value="Hinzufügen"
 									actionListener="#{lessonController.addLesson}"
 									process="addLessonType,lessonWeekday,lessonStartTime,lessonEndTime,lessonTeachers,lessonSchoolclassPanel,lessonRoomPanel,@this"
-									update="activityMessages,addActivityPanel,searchTabs,scheduleMain" />
+									update="activityMessages,activityGrowl,addActivityPanel,searchTabs,scheduleMain" validateClient="true" />
 							</p:outputPanel>
 						</h:panelGrid>
 					</p:outputPanel>
@@ -591,7 +592,7 @@
 								<p:commandButton value="Hinzufügen"
 									actionListener="#{meetingController.addMeeting}"
 									process="addMeetingType,meetingWeekday,meetingStartTime,meetingEndTime,meetingEmployees,meetingRoomPanel,@this"
-									update="activityMessages,addActivityPanel,searchTabs,scheduleMain" />
+									update="activityMessages,activityGrowl,addActivityPanel,searchTabs,scheduleMain" />
 							</p:outputPanel>
 						</h:panelGrid>
 					</p:outputPanel>
@@ -654,7 +655,7 @@
 								<p:commandButton value="Hinzufügen"
 									actionListener="#{pauseController.addPause}"
 									process="pauseWeekday,pauseStartTime,pauseEndTime,pauseSchoolclasses,@this"
-									update="activityMessages,addActivityPanel,searchTabs,scheduleMain" />
+									update="activityMessages,activityGrowl,addActivityPanel,searchTabs,scheduleMain" />
 							</p:outputPanel>
 						</h:panelGrid>
 
@@ -781,7 +782,7 @@
 								<p:commandButton value="Hinzufügen"
 									actionListener="#{compoundLessonController.addCompoundLesson}"
 									process="compoundLessonWeekday,compoundLessonStartTime,compoundLessonEndTime,compoundLessonEmployees,compoundLessonSchoolclasses,compoundLessonRoomPanel,@this"
-									update="activityMessages,addActivityPanel,searchTabs,scheduleMain" />
+									update="activityMessages,activityGrowl,addActivityPanel,searchTabs,scheduleMain" />
 							</p:outputPanel>
 						</h:panelGrid>
 
@@ -790,7 +791,7 @@
 
 				<p:outputPanel style="clear:right; margin-top:60px;">
 					<p:messages id="activityMessages" showDetail="true"
-						closable="false" />
+						closable="false" severity="error" />
 				</p:outputPanel>
 			</p:outputPanel>
 		</p:dialog>


### PR DESCRIPTION
Es wurde ein weiteres p:growl-Element erstellt und diesem die Level "INFO" und "WARN" zugeordnet. Die Nachrichten im Aktivitätsdialog selbst wurden auf "ERROR" gestellt. Beide Elemente werden nacheinander aktualisiert und so die Nachrichten gefiltert.

Der normale p:Growl ist weiter vorhanden, sodass die Nachrichten im Drag&Drop weiterhin funktionieren.