### PR TITLE
ActivityParser verschoben

### DIFF
--- a/src/main/java/org/woym/ui/util/ActivityParser.java
+++ b/src/main/java/org/woym/ui/util/ActivityParser.java
@@ -1,4 +1,4 @@
-package org.woym.logic.util;
+package org.woym.ui.util;
 
 import java.util.ArrayList;
 import java.util.Calendar;

--- a/src/main/java/org/woym/ui/util/EmployeeDailyViewHelper.java
+++ b/src/main/java/org/woym/ui/util/EmployeeDailyViewHelper.java
@@ -3,7 +3,6 @@ package org.woym.ui.util;
 import org.primefaces.model.ScheduleModel;
 import org.woym.common.objects.Employee;
 import org.woym.controller.planning.PlanningController;
-import org.woym.logic.util.ActivityParser;
 
 /**
  * <h1>EmployeeDailyViewHelper</h1>

--- a/src/main/java/org/woym/ui/util/PersonalPlanHelper.java
+++ b/src/main/java/org/woym/ui/util/PersonalPlanHelper.java
@@ -17,7 +17,6 @@ import org.woym.common.objects.Lesson;
 import org.woym.common.objects.Teacher;
 import org.woym.common.objects.Weekday;
 import org.woym.controller.planning.PlanningController;
-import org.woym.logic.util.ActivityParser;
 import org.woym.persistence.DataAccess;
 
 /**

--- a/src/main/java/org/woym/ui/util/ScheduleModelHolder.java
+++ b/src/main/java/org/woym/ui/util/ScheduleModelHolder.java
@@ -11,7 +11,6 @@ import org.woym.common.objects.Room;
 import org.woym.common.objects.Schoolclass;
 import org.woym.common.objects.Teacher;
 import org.woym.controller.planning.PlanningController;
-import org.woym.logic.util.ActivityParser;
 
 /**
  * <h1>ScheduleModelHolder</h1>

--- a/src/test/java/org/woym/logic/util/ActivityParserTest.java
+++ b/src/test/java/org/woym/logic/util/ActivityParserTest.java
@@ -34,6 +34,7 @@ import org.woym.common.objects.Teacher;
 import org.woym.common.objects.TimePeriod;
 import org.woym.common.objects.Weekday;
 import org.woym.persistence.DataAccess;
+import org.woym.ui.util.ActivityParser;
 
 @Test(groups = "unit")
 @PowerMockIgnore("javax.management.*")


### PR DESCRIPTION
ActivityParser verschoben, so dass sich im Paket org.woym.ui.util alle Klassen befinden, die in irgendeiner Weise für die korrekte Darstellung innerhalb der GUI notwendig sind.